### PR TITLE
Remove filesystem dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,14 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.7.0
-
-jobs:
-  build:
-    machine: true
-    steps:
-    - checkout
-
-    - run: |
-        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-        chmod +x ./architect
-        ./architect version
-    - run: ./architect build
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./resource-police
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
+  architect: giantswarm/architect@0.10.0
 
 workflows:
-  package-and-push-chart-on-tag:
+  build:
     jobs:
-      - build:
+      - architect/go-build:
+          name: build
+          binary: resource-police
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.10.0
+  architect: giantswarm/architect@0.10.1
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Moved report template to go source file so it can be read when running in a container.
+
+[Unreleased]: https://github.com/giantswarm/resource-police/compare/v0.0.0...HEAD

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/giantswarm/micrologger v0.3.1
 	github.com/go-openapi/runtime v0.19.19
 	github.com/go-openapi/strfmt v0.19.5
+	github.com/google/go-cmp v0.4.0
 	github.com/hako/durafmt v0.0.0-20200605151348-3a43fc422dd9
 	github.com/spf13/cobra v1.0.0
 )

--- a/helm/resource-police/Chart.yaml
+++ b/helm/resource-police/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 appVersion: [[ .AppVersion ]]
 description: Report about tenant clusters in test installations
 home: https://github.com/giantswarm/resource-police

--- a/helm/resource-police/Chart.yaml
+++ b/helm/resource-police/Chart.yaml
@@ -1,4 +1,4 @@
-appVersion: [[ .Version ]]
+appVersion: [[ .AppVersion ]]
 description: Report about tenant clusters in test installations
 home: https://github.com/giantswarm/resource-police
 name: resource-police

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func mainE(ctx context.Context) error {
 		}
 
 		rootCommand, err = cmd.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	err = rootCommand.Execute()

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -147,7 +147,7 @@ func ListClusters(i Installation) ([]*Cluster, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		age := time.Now().Sub(created)
+		age := time.Since(created)
 
 		if age < AgeLimit {
 			// We skip clusters that are younger than 3 hours.
@@ -182,7 +182,7 @@ func ListClusters(i Installation) ([]*Cluster, error) {
 
 		// If required labels are set, we look at the keep-until value
 		if c.Creator != "" {
-			if c.KeepUntil.Sub(time.Now()) > 0 {
+			if time.Until(c.KeepUntil) > 0 {
 				continue
 			}
 		}

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -180,7 +180,7 @@ func ListClusters(i Installation) ([]*Cluster, error) {
 			}
 		}
 
-		// If required labels are set, we look at the kee-until value
+		// If required labels are set, we look at the keep-until value
 		if c.Creator != "" {
 			if c.KeepUntil.Sub(time.Now()) > 0 {
 				continue
@@ -196,19 +196,14 @@ func ListClusters(i Installation) ([]*Cluster, error) {
 func RenderReport(clusters []*Cluster) (string, error) {
 	fmt.Println("Rendering report")
 
-	templateCode, err := ioutil.ReadFile("./pkg/installation/report.gotemplate")
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	t := template.Must(template.New("report-template").Parse(string(templateCode)))
+	t := template.Must(template.New("report-template").Parse(reportTemplate))
 
 	myData := TemplateData{
 		Clusters: clusters,
 	}
 
 	var renderedReport bytes.Buffer
-	err = t.Execute(&renderedReport, myData)
+	err := t.Execute(&renderedReport, myData)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -1,0 +1,39 @@
+package installation
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const expectedRenderedReport = `*Test clusters that should be deleted*
+
+- ` + "`ginger` / `abc12`" + ` - cluster (1d old) - ping @creator
+- ` + "`gaia` / `def34`" + ` - other (2d old)
+
+Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environments/|our policy> on how to keep test clusters alive.
+`
+
+func Test_RenderReport(t *testing.T) {
+	report, err := RenderReport([]*Cluster{
+		{
+			ID:               "abc12",
+			Name:             "cluster",
+			AgeString:        "1d",
+			Creator:          "creator",
+			InstallationName: "ginger",
+		},
+		{
+			ID:               "def34",
+			Name:             "other",
+			AgeString:        "2d",
+			InstallationName: "gaia",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %s", err)
+	}
+	if !cmp.Equal(expectedRenderedReport, report) {
+		t.Fatalf("report doesn't match expected: %s", cmp.Diff(expectedRenderedReport, report))
+	}
+}

--- a/pkg/installation/report.gotemplate
+++ b/pkg/installation/report.gotemplate
@@ -1,6 +1,0 @@
-*Test clusters that should be deleted*
-
-{{ range  .Clusters -}}
-- `{{ .InstallationName }}` / `{{ .ID }}` - {{ .Name }} ({{ .AgeString }} old) {{ with .Creator }} - ping @{{ .Creator }}{{ end }}
-{{ end }}
-Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environments/|our policy> on how to keep test clusters alive.

--- a/pkg/installation/template.go
+++ b/pkg/installation/template.go
@@ -1,0 +1,11 @@
+package installation
+
+// Backticks in multi-line strings can't be escaped, so we're appending a normal double quoted string containing
+// backticks in the middle of this template.
+const reportTemplate = `*Test clusters that should be deleted*
+
+{{ range  .Clusters -}}
+- ` + "`{{ .InstallationName }}` / `{{ .ID }}`" + ` - {{ .Name }} ({{ .AgeString }} old){{ with .Creator }} - ping @{{ . }}{{ end }}
+{{ end }}
+Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environments/|our policy> on how to keep test clusters alive.
+`


### PR DESCRIPTION
Fixing this issue resulting from the binary not having access to the source tree when running in a docker container by moving the template back into a go source file:
```json
{
  "caller": "resource-police/main.go:50",
  "level": "error",
  "message": "failed to execute command",
  "stack": {
    "annotation": "open ./pkg/installation/report.gotemplate: no such file or directory",
    "kind": "unknown",
    "stack": [
      {
        "file": "/go/src/github.com/giantswarm/resource-police/pkg/installation/installation.go",
        "line": 201
      },
      {
        "file": "/go/src/github.com/giantswarm/resource-police/cmd/report/runner.go",
        "line": 74
      },
      {
        "file": "/go/src/github.com/giantswarm/resource-police/cmd/report/runner.go",
        "line": 33
      }
    ]
  },
  "time": "2020-07-27T16:22:07.968047+00:00"
}
```
Also made some minor changes and added a unit test.