### PR TITLE
Collect errors while scanning installations and report them, but don't fail

### DIFF
--- a/cmd/report/runner.go
+++ b/cmd/report/runner.go
@@ -64,7 +64,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				clustersToDelete = append(clustersToDelete, clusters...)
 			} else {
 				// collect errors, but continue
-				errors = append(errors, fmt.Sprintf("Could not list cluster in installation `%s`: `%s`", i.Name, err))
+				errors = append(errors, fmt.Sprintf("Could not list clusters in installation `%s`: `%s`", i.Name, err))
 			}
 		}
 	}

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -70,6 +70,7 @@ type Installation struct {
 
 type TemplateData struct {
 	Clusters []*Cluster
+	Errors   []string
 }
 
 func New(config Config) (installations []Installation, err error) {
@@ -197,13 +198,14 @@ func ListClusters(i Installation) ([]*Cluster, error) {
 	return clustersToDelete, nil
 }
 
-func RenderReport(clusters []*Cluster) (string, error) {
+func RenderReport(clusters []*Cluster, errors []string) (string, error) {
 	fmt.Println("Rendering report")
 
 	t := template.Must(template.New("report-template").Parse(reportTemplate))
 
 	myData := TemplateData{
 		Clusters: clusters,
+		Errors:   errors,
 	}
 
 	var renderedReport bytes.Buffer

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -12,6 +12,15 @@ const expectedRenderedReport = `*Test clusters that should be deleted*
 - ` + "`gaia` / `def34`" + ` - other (2d old)
 
 Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environments/|our policy> on how to keep test clusters alive.
+
+By the way, some errors occurred:
+
+- An error occurred
+
+Please check the resource-police configuration and installation IP whitelists to ensure
+that all installations are accessible by resource-police.
+
+
 `
 
 func Test_RenderReport(t *testing.T) {

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -15,11 +15,11 @@ Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environmen
 
 By the way, some errors occurred:
 
-- An error occurred
+- First error
+- Second error
 
 Please check the resource-police configuration and installation IP whitelists to ensure
 that all installations are accessible by resource-police.
-
 
 `
 
@@ -38,7 +38,9 @@ func Test_RenderReport(t *testing.T) {
 			AgeString:        "2d",
 			InstallationName: "gaia",
 		},
-	}, []string{"An error occurred"})
+	}, []string{
+		"First error",
+		"Second error"})
 	if err != nil {
 		t.Fatalf("expected err to be nil, got %s", err)
 	}

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -29,7 +29,7 @@ func Test_RenderReport(t *testing.T) {
 			AgeString:        "2d",
 			InstallationName: "gaia",
 		},
-	})
+	}, []string{"An error occurred"})
 	if err != nil {
 		t.Fatalf("expected err to be nil, got %s", err)
 	}

--- a/pkg/installation/template.go
+++ b/pkg/installation/template.go
@@ -8,4 +8,15 @@ const reportTemplate = `*Test clusters that should be deleted*
 - ` + "`{{ .InstallationName }}` / `{{ .ID }}`" + ` - {{ .Name }} ({{ .AgeString }} old){{ with .Creator }} - ping @{{ . }}{{ end }}
 {{ end }}
 Please check <https://intranet.giantswarm.io/docs/dev-and-releng/test-environments/|our policy> on how to keep test clusters alive.
+
+{{ if .Errors -}}
+By the way, some errors occurred:
+
+{{ range  .Errors -}}
+- {{ . }}
+
+Please check the resource-police configuration and installation IP whitelists to ensure
+that all installations are accessible by resource-police.
+{{ end }}
+{{ end }}
 `

--- a/pkg/installation/template.go
+++ b/pkg/installation/template.go
@@ -14,9 +14,8 @@ By the way, some errors occurred:
 
 {{ range  .Errors -}}
 - {{ . }}
-
+{{ end }}
 Please check the resource-police configuration and installation IP whitelists to ensure
 that all installations are accessible by resource-police.
-{{ end }}
 {{ end }}
 `


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/11882

This PR mitigates the problem that the entire resource-police job fails if there is a problem with an installation. Common problems are:

- Installation no longer available
- User credentials not valid

These errors are now collected and reported if they occur, assuming that nobody will otherwise see them.

Example:

![image](https://user-images.githubusercontent.com/273727/89548836-ce8ded80-d807-11ea-96dc-80d6cc8fa2d6.png)
