### PR TITLE
Group clusters by age, show release version

### DIFF
--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -22,7 +22,7 @@ const (
 	// and more expensive the query.
 	timeRange = 1 * 24 * time.Hour
 
-	// If a cluster has been last more than this much time ago,
+	// If a cluster has been last seen more than this much time ago,
 	// it is considered deleted. Be careful to make this at least as
 	// large as the stepInterval.
 	lastSeenDurationThreshold = time.Hour

--- a/pkg/report/golden/error.golden
+++ b/pkg/report/golden/error.golden
@@ -1,5 +1,8 @@
 
 
+
+
+
 Some errors occurred:
 
 - nothing but failure

--- a/pkg/report/golden/success.golden
+++ b/pkg/report/golden/success.golden
@@ -1,7 +1,12 @@
-*Test clusters that should be deleted*
+*Test clusters older than three days*
 
-- `gaia` / `def34`
-- `ginger` / `abc12`
+- `ginger` / `abc12` (v1.2.3-myversion)
+
+
+*Test clusters older than three hours*
+
+- `gaia` / `def34` (v1.2.3)
+
 
 
 Some errors occurred:

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -5,44 +5,57 @@ package report
 import (
 	"bytes"
 	"embed"
-	"fmt"
-	"strings"
+	"log"
+	"sort"
 	"text/template"
+	"time"
 
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/resource-police/pkg/cortex"
 )
 
 //go:embed template.gotmpl
 var f embed.FS
 
-type Cluster struct {
-	ID               string
-	InstallationName string
-}
-
 type TemplateData struct {
-	Clusters []Cluster
-	Errors   []error
+	Clusters3Days  []cortex.Cluster
+	Clusters1Day   []cortex.Cluster
+	Clusters3Hours []cortex.Cluster
+	ClustersRest   []cortex.Cluster
+	Errors         []error
 }
 
-func Render(clusters []string, errors []error) (string, error) {
-	fmt.Println("Rendering report")
+func Render(clusters []cortex.Cluster, errors []error) (string, error) {
+	log.Println("Rendering report")
 
 	reportTemplate, _ := f.ReadFile("template.gotmpl")
 
 	t := template.Must(template.New("report-template").Parse(string(reportTemplate)))
 
 	myData := TemplateData{
-		Clusters: []Cluster{},
-		Errors:   errors,
+		Errors: errors,
 	}
 
-	for _, c := range clusters {
-		parts := strings.Split(c, "/")
-		myData.Clusters = append(myData.Clusters, Cluster{
-			ID:               parts[1],
-			InstallationName: parts[0],
-		})
+	// Sort by installation name
+	sort.Slice(clusters, func(i, j int) bool {
+		return clusters[i].Installation < clusters[j].Installation
+	})
+
+	// Group clusters by age
+	// (more than 3 days, more than 1 day, more than 3 hours, rest).
+	now := time.Now().UTC()
+	for i := 0; i < len(clusters); i++ {
+		switch age := now.Sub(clusters[i].FirstTimestamp); {
+		case age > 3*24*time.Hour:
+			myData.Clusters3Days = append(myData.Clusters3Days, clusters[i])
+		case age > 24*time.Hour:
+			myData.Clusters1Day = append(myData.Clusters1Day, clusters[i])
+		case age > 3*time.Hour:
+			myData.Clusters3Hours = append(myData.Clusters3Hours, clusters[i])
+		default:
+			myData.ClustersRest = append(myData.ClustersRest, clusters[i])
+		}
 	}
 
 	var renderedReport bytes.Buffer
@@ -51,7 +64,7 @@ func Render(clusters []string, errors []error) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	fmt.Println("Report has been rendered")
+	log.Println("Report has been rendered")
 
 	return renderedReport.String(), nil
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -4,8 +4,11 @@ import (
 	"embed"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/giantswarm/resource-police/pkg/cortex"
 )
 
 //go:embed golden/*
@@ -14,19 +17,32 @@ var fs embed.FS
 func Test_RenderReport(t *testing.T) {
 	tests := []struct {
 		name       string
-		clusters   []string
+		clusters   []cortex.Cluster
 		errors     []error
 		goldenFile string
 	}{
 		{
-			name:       "Success",
-			clusters:   []string{"gaia/def34", "ginger/abc12"},
+			name: "Success",
+			clusters: []cortex.Cluster{
+				{
+					Installation:   "gaia",
+					ID:             "def34",
+					Release:        "1.2.3",
+					FirstTimestamp: time.Now().UTC().Add(-4 * time.Hour),
+				},
+				{
+					Installation:   "ginger",
+					ID:             "abc12",
+					Release:        "1.2.3-myversion",
+					FirstTimestamp: time.Now().UTC().Add(-5 * 24 * time.Hour),
+				},
+			},
 			errors:     []error{errors.New("First error"), errors.New("Second error")},
 			goldenFile: "success.golden",
 		},
 		{
 			name:       "Errors-only",
-			clusters:   []string{},
+			clusters:   []cortex.Cluster{},
 			errors:     []error{errors.New("nothing but failure")},
 			goldenFile: "error.golden",
 		},

--- a/pkg/report/template.gotmpl
+++ b/pkg/report/template.gotmpl
@@ -1,8 +1,29 @@
-{{- if .Clusters -}}
-*Test clusters that should be deleted*
+{{- if .Clusters3Days -}}
+*Test clusters older than three days*
 
-{{ range  .Clusters -}}
-- `{{ .InstallationName }}` / `{{ .ID }}`
+{{ range  .Clusters3Days -}}
+- `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+{{ end }}
+{{- end }}
+{{ if .Clusters1Day -}}
+*Test clusters older than a day*
+
+{{ range  .Clusters1Day -}}
+- `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+{{ end }}
+{{- end }}
+{{ if .Clusters3Hours -}}
+*Test clusters older than three hours*
+
+{{ range  .Clusters3Hours -}}
+- `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+{{ end }}
+{{- end }}
+{{ if .ClustersRest -}}
+*Newer test clusters*
+
+{{ range  .ClustersRest -}}
+- `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
 {{ end }}
 {{- end }}
 

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -3,7 +3,7 @@ package slack
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/giantswarm/microerror"
@@ -39,7 +39,7 @@ func New(config Config) (*Slack, error) {
 }
 
 func (s *Slack) SendReport(report string) error {
-	fmt.Println("Sending report to slack...")
+	log.Println("Sending report to slack...")
 
 	requestBody, err := json.Marshal(map[string]string{
 		"text": report,
@@ -53,7 +53,7 @@ func (s *Slack) SendReport(report string) error {
 		return microerror.Mask(err)
 	}
 
-	fmt.Println("Report has been sent.")
+	log.Println("Report has been sent.")
 
 	return nil
 }


### PR DESCRIPTION
This PR attempts to add structure and details to the report generated, to make it more actionable.

### Preview

![image](https://user-images.githubusercontent.com/273727/116198153-e9a5e200-a735-11eb-8cc7-9d73102cf495.png)

If there are clusters older than three days, there will be a group for them at the top of the report. Plus, for cluster younger than three hours, there will be another group at the end.