### PR TITLE
Fix query time range, add --dryrun flag

### DIFF
--- a/cmd/report/flag.go
+++ b/cmd/report/flag.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	flagDryRun = "dryrun"
+
 	flagSlackWebhookEndpoint = "slack.webhook.endpoint"
 
 	flagCortexEndpoint = "cortex.endpoint.url"
@@ -18,6 +20,8 @@ const (
 )
 
 type flag struct {
+	DryRun bool
+
 	SlackWebhookEndpoint string
 
 	CortexEndpoint string
@@ -26,6 +30,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.DryRun, flagDryRun, false, "Set this to print the report to STDOUT and avoid sending it to Slack")
 	cmd.Flags().StringVar(&f.SlackWebhookEndpoint, flagSlackWebhookEndpoint, os.Getenv(env.SlackWebhookEndpoint), "Slack Webhook endpoint for posting messages into channel")
 	cmd.Flags().StringVar(&f.CortexEndpoint, flagCortexEndpoint, "https://prometheus-us-central1.grafana.net/api/prom", "Cortex endpoint URL")
 	cmd.Flags().StringVar(&f.CortexUsername, flagCortexUsername, os.Getenv(env.CortexUserName), "Cortex user ID")

--- a/cmd/report/runner.go
+++ b/cmd/report/runner.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/giantswarm/microerror"
@@ -60,6 +61,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	report, err := report.Render(clusters, errors)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	if r.flag.DryRun {
+		fmt.Printf("\nReport:\n\n")
+		fmt.Println(report)
+		return nil
 	}
 
 	var slackService *slack.Slack

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -20,7 +20,7 @@ const (
 
 	// Amount of time to look back. The longer the time frame, the slower
 	// and more expensive the query.
-	timeRange = 1 * 24 * time.Hour
+	timeRange = 7 * 24 * time.Hour
 
 	// If a cluster has been last seen more than this much time ago,
 	// it is considered deleted. Be careful to make this at least as
@@ -145,6 +145,7 @@ func (s Service) QueryClusters() ([]Cluster, error) {
 				// Skip as not existing any more.
 				continue
 			}
+
 			c := Cluster{
 				Installation:   installation,
 				ID:             clusterID,

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "resource-police"
 	source      = "https://github.com/giantswarm/resource-police"
-	version     = "1.1.0"
+	version     = "1.1.0-dev"
 )
 
 func Description() string {

--- a/pkg/report/golden/success.golden
+++ b/pkg/report/golden/success.golden
@@ -2,11 +2,17 @@
 
 - `ginger` / `abc12` (v1.2.3-myversion)
 
+:money_with_wings: Test clusters older than a day - Please delete yours if no longer needed.
+
+- `blah` / `t2ayx` (v13.0.4)
 
 :awareness_ribbon: Test clusters older than three hours
 
 - `gaia` / `def34` (v1.2.3)
 
+:seedling: Newer test clusters
+
+- `foobar` / `r72ux` (v14.5.6)
 
 
 :warning: Some errors occurred:

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -24,12 +24,28 @@ func Test_RenderReport(t *testing.T) {
 		{
 			name: "Success",
 			clusters: []cortex.Cluster{
+				// 2 hours old cluster
+				{
+					Installation:   "foobar",
+					ID:             "r72ux",
+					Release:        "14.5.6",
+					FirstTimestamp: time.Now().UTC().Add(-2 * time.Hour),
+				},
+				// 4 hours old cluster
 				{
 					Installation:   "gaia",
 					ID:             "def34",
 					Release:        "1.2.3",
 					FirstTimestamp: time.Now().UTC().Add(-4 * time.Hour),
 				},
+				// 2 days old cluster
+				{
+					Installation:   "blah",
+					ID:             "t2ayx",
+					Release:        "13.0.4",
+					FirstTimestamp: time.Now().UTC().Add(-2 * 24 * time.Hour),
+				},
+				// 5 days old cluster
 				{
 					Installation:   "ginger",
 					ID:             "abc12",


### PR DESCRIPTION
This PR

- fixes the amount of time we look back at cortex data, in order to determine whether clusters have been running for several days already
- adds a flag `--dry-run` to simplify testing and development
- improves the report test to cover all age groups