### PR TITLE
Add support for CAPI clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add team label in resources.
+- Add support for CAPI clusters.
 
 ## [1.3.1] - 2023-11-30
 

--- a/pkg/report/template.gotmpl
+++ b/pkg/report/template.gotmpl
@@ -2,28 +2,28 @@
 :computer-fire: Test clusters *older than three days* - *Please delete these!*
 
 {{ range  .Clusters3Days -}}
-- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}`{{ if .Release }} (v{{ .Release }}){{ end }}
 {{ end }}
 {{- end }}
 {{ if .Clusters1Day -}}
 :money_with_wings: Test clusters older than a day - Please delete yours if no longer needed.
 
 {{ range  .Clusters1Day -}}
-- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}`{{ if .Release }} (v{{ .Release }}){{ end }}
 {{ end }}
 {{- end }}
 {{ if .Clusters3Hours -}}
 :awareness_ribbon: Test clusters older than three hours
 
 {{ range  .Clusters3Hours -}}
-- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}`{{ if .Release }} (v{{ .Release }}){{ end }}
 {{ end }}
 {{- end }}
 {{ if .ClustersRest -}}
 :seedling: Newer test clusters
 
 {{ range  .ClustersRest -}}
-- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}` (v{{ .Release }})
+- `{{ .Provider }}` / `{{ .Installation }}` / `{{ .ID }}`{{ if .Release }} (v{{ .Release }}){{ end }}
 {{ end }}
 {{- end }}
 


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/30217

Use another metric, containing both vintage and CAPI data, and make `release` optional