### PR TITLE
Migrate to App Build Suite (ABS)

### DIFF
--- a/.abs/.kube-linter.yaml
+++ b/.abs/.kube-linter.yaml
@@ -1,0 +1,6 @@
+checks:
+  exclude:
+    # Resource requirements should be set based on actual usage data
+    - unset-cpu-requirements
+    - unset-memory-requirements
+

--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -4,4 +4,5 @@ generate-metadata: true
 chart-dir: ./helm/resource-police
 destination: build
 catalog-base-url: https://giantswarm.github.io/giantswarm-operations-platform-test-catalog/
+kubelinter-config: .abs/.kube-linter.yaml
 

--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,7 @@
+replace-chart-version-with-git: true
+replace-app-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/resource-police
+destination: build
+catalog-base-url: https://giantswarm.github.io/giantswarm-operations-platform-test-catalog/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,18 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@5.6.0
+  architect: giantswarm/architect@6.11.0
 
 workflows:
   build:
     jobs:
-    - architect/go-build:
-        name: build
-        binary: resource-police
-        filters:
-          tags:
-            only: /^v.*/
-
-    - architect/push-to-registries:
-        context: architect
-        name: push-to-registries
-        requires:
-        - build
-        filters:
-          tags:
-            only: /^v.*/
-
-          branches:
-            ignore:
-            - main
-            - master
     - architect/push-to-app-catalog:
         context: architect
+        executor: app-build-suite
         name: package and push resource-police
         app_catalog: giantswarm-operations-platform-catalog
         app_catalog_test: giantswarm-operations-platform-test-catalog
         chart: resource-police
-        requires:
-        - push-to-registries
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,26 @@ orbs:
 workflows:
   build:
     jobs:
+    - architect/go-build:
+        name: build
+        binary: resource-police
+        filters:
+          tags:
+            only: /^v.*/
+
+    - architect/push-to-registries:
+        context: architect
+        name: push-to-registries
+        requires:
+        - build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+            - master
+
     - architect/push-to-app-catalog:
         context: architect
         executor: app-build-suite
@@ -13,6 +33,8 @@ workflows:
         app_catalog: giantswarm-operations-platform-catalog
         app_catalog_test: giantswarm-operations-platform-test-catalog
         chart: resource-police
+        requires:
+        - push-to-registries
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to App Build Suite (ABS) for Helm chart building.
+
 ## [1.6.0] - 2025-10-08
 
 ### Changed

--- a/helm/resource-police/Chart.yaml
+++ b/helm/resource-police/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-appVersion: [[ .AppVersion ]]
+apiVersion: v2
+appVersion: 1.6.0-dev
 description: Report about tenant clusters in test installations
 home: https://github.com/giantswarm/resource-police
 name: resource-police
-version: [[ .Version ]]
+version: 1.6.0-dev
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:
-  application.giantswarm.io/team: phoenix
+  io.giantswarm.application.team: phoenix

--- a/helm/resource-police/templates/_helpers.tpl
+++ b/helm/resource-police/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 {{- if .Values.image.tag }}
 {{- .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
 {{- else }}
-{{- .Values.image.registry }}/{{ .Values.image.name }}:{{ .Chart.Version }}
+{{- .Values.image.registry }}/{{ .Values.image.name }}:{{ .Chart.AppVersion }}
 {{- end -}}
 {{- end -}}
 
@@ -13,5 +13,5 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ .Values.name }}
 giantswarm.io/service-type: "managed"
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end -}}


### PR DESCRIPTION
This PR migrates the repository to use App Build Suite (ABS) for Helm chart building.

## Changes

- Update architect orb to 6.11.0
- Add `executor: app-build-suite` to push-to-app-catalog job
- Remove `go-build` and `push-to-registries` jobs (handled by ABS)
- Create `.abs/main.yaml` with ABS configuration
- Update `Chart.yaml`:
  - Upgrade apiVersion from v1 to v2
  - Add icon
  - Update team annotation to OpenContainers format (`io.giantswarm.application.team`)
  - Replace version/appVersion placeholders with dev versions
- Update `_helpers.tpl` to read from new annotation format and use AppVersion for image tag fallback

## Testing

CI will validate the ABS migration by running the new build pipeline.